### PR TITLE
Build missing Python 3.14 wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,8 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
+          allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -84,6 +86,8 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
+          allow-prereleases: true
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -118,7 +122,9 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
           architecture: ${{ matrix.platform.target }}
+          allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -151,6 +157,8 @@ jobs:
             3.11
             3.12
             3.13
+            3.14
+          allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
Currently only `rignore-<ver>-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` and `
rignore-<ver>-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl` are
being built and published, so this should fix that.
