### PR TITLE
Update PyO3 to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "portable-atomic"
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "indoc",
  "libc",
@@ -160,19 +160,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -180,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -192,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ignore = "0.4.23"
-pyo3 = "0.25.1"
+pyo3 = "0.26.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl Walker {
 
         case_insensitive: Option<bool>,
         same_file_system: Option<bool>,
-        should_exclude_entry: Option<PyObject>,
+        should_exclude_entry: Option<Py<PyAny>>,
     ) -> Self {
         let mut builder = ignore::WalkBuilder::new(path);
 
@@ -123,7 +123,7 @@ impl Walker {
 
         if let Some(filter_func) = should_exclude_entry {
             let filter = Arc::new(move |entry: &ignore::DirEntry| -> PyResult<bool> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let path_buf = entry.path().to_path_buf();
                     let pathlib_path = path_buf_to_pathlib_path(py, path_buf)?;
                     let args = (pathlib_path,);
@@ -210,7 +210,7 @@ fn walk(
     case_insensitive: Option<bool>,
     same_file_system: Option<bool>,
 
-    should_exclude_entry: Option<PyObject>,
+    should_exclude_entry: Option<Py<PyAny>>,
 ) -> PyResult<Walker> {
     Ok(Walker::new(
         path,


### PR DESCRIPTION
https://pyo3.rs/v0.26.0/migration.html

- `Python::with_gil` was renamed to `Python::attach` (the old name is still available for now, but deprecated)
- the `PyObject` alias was deprecated in favor of `Py<PyAny>`