### PR TITLE
Build Windows ARM64 wheels in maturin

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,11 +116,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        if: matrix.platform.target != 'arm64'
         with:
           python-version: |
             3.8
             3.9
             3.10
+            3.11
+            3.12
+            3.13
+            3.14
+          architecture: ${{ matrix.platform.target }}
+          allow-prereleases: true
+      - uses: actions/setup-python@v5
+        if: matrix.platform.target == 'arm64'
+        with:
+          python-version: |
             3.11
             3.12
             3.13

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,8 +107,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: windows-11-arm
-            target: arm64
           - runner: windows-latest
             target: x64
           - runner: windows-latest
@@ -128,16 +126,6 @@ jobs:
             3.14
           architecture: ${{ matrix.platform.target }}
           allow-prereleases: true
-      - uses: actions/setup-python@v5
-        if: matrix.platform.target == 'arm64'
-        with:
-          python-version: |
-            3.11
-            3.12
-            3.13
-            3.14
-          architecture: ${{ matrix.platform.target }}
-          allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -148,6 +136,30 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
+          path: dist
+  windows-arm:
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.11
+            3.12
+            3.13
+            3.14
+          architecture: arm64
+          allow-prereleases: true
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: aarch64
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-arm64
           path: dist
 
   macos:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,6 +107,8 @@ jobs:
     strategy:
       matrix:
         platform:
+          - runner: windows-11-arm
+            target: arm64
           - runner: windows-latest
             target: x64
           - runner: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 license = {text = "MIT"}
 
 [build-system]
-requires = ["maturin>=1.8.3,<2.0"]
+requires = ["maturin>=1.9.5,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]
@@ -29,7 +29,7 @@ distribution = true
 dev = [
     "pytest>=8.2.2",
     "typing-extensions>=4.12.2",
-    "maturin>=1.8.3",
+    "maturin>=1.9.5",
 ]
 
 [tool.pdm.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 license = {text = "MIT"}
 
 [build-system]
-requires = ["maturin>=1.9.5,<2.0"]
+requires = ["maturin>=1.9.6,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]
@@ -29,7 +29,7 @@ distribution = true
 dev = [
     "pytest>=8.2.2",
     "typing-extensions>=4.12.2",
-    "maturin>=1.9.5",
+    "maturin>=1.9.6",
 ]
 
 [tool.pdm.scripts]


### PR DESCRIPTION
Maturin now supports Windows ARM64. This pull request adds the Windows/ARM64 runner and builds wheels. Since Python only started supporting ARM in 3.11, the runner is separated with a different matrix.

Fixes #14 