### PR TITLE
Make snapshot tests order-insensitive

### DIFF
--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -38,7 +38,7 @@ def folder(tmp_path: str, folder_structure: list[str]) -> Path:
 
 
 def test_basic_walk(folder: Path, folder_structure: list[str]):
-    paths = [str(path.relative_to(folder)) for path in rignore.walk(folder)]
+    paths = sorted(str(path.relative_to(folder)) for path in rignore.walk(folder))
 
     assert paths == snapshot(
         [
@@ -57,18 +57,18 @@ def test_filter_entry(folder: Path):
     def should_exclude(entry: Path) -> bool:
         return entry.name == "some_folder"
 
-    paths = [
+    paths = sorted(
         str(path.relative_to(folder))
         for path in rignore.walk(folder, should_exclude_entry=should_exclude)
-    ]
+    )
 
     assert paths == snapshot([".", "an_image.jpg", "some_file.txt"])
 
 
 def test_overrides(folder: Path):
-    paths = [
+    paths = sorted(
         str(path.relative_to(folder))
         for path in rignore.walk(folder, overrides=[".hidden"])
-    ]
+    )
 
     assert paths == snapshot([".", ".hidden", "some_folder", "some_folder/some_folder"])


### PR DESCRIPTION
Sort walked paths since the order in which they are generated may vary.

We could have compared sets of paths, but the sorting approach will still detect duplicate paths, should they ever occur.

This fixes issues like this (observed on Fedora):

```
tests/test_walk.py::test_basic_walk PASSED                                            [ 33%]
tests/test_walk.py::test_basic_walk ERROR                                             [ 33%]
tests/test_walk.py::test_filter_entry PASSED                                          [ 66%]
tests/test_walk.py::test_overrides PASSED                                             [100%]
tests/test_walk.py::test_overrides ERROR                                              [100%]

══════════════════════════════════════ inline-snapshot ══════════════════════════════════════
─────────────────────────────────────── Fix snapshots ───────────────────────────────────────
╭─────────────────────────────────── tests/test_walk.py ────────────────────────────────────╮
│ @@ -43,13 +43,8 @@                                                                        │
│                                                                                           │
│      assert paths == snapshot(                                                            │
│          [                                                                                │
│              ".",                                                                         │
│ -            "an_image.jpg",                                                              │
│ -            "some_file.txt",                                                             │
│ -            "some_folder",                                                               │
│ -            "some_folder/some_file.txt",                                                 │
│ -            "some_folder/some_folder",                                                   │
│ -            "some_folder/some_folder/some_file.txt",                                     │
│ -        ]                                                                                │
│ +            "an_image.jpg", "some_folder", "some_folder/some_folder",                    │
│ +            "some_folder/some_folder/some_file.txt", 'some_folder/some_file.txt',        │
│ 'some_file.txt']                                                                          │
│      )                                                                                    │
│                                                                                           │
│                                                                                           │
│ @@ -71,4 +66,4 @@                                                                         │
│                                                                                           │
│          for path in rignore.walk(folder, overrides=[".hidden"])                          │
│      ]                                                                                    │
│                                                                                           │
│ -    assert paths == snapshot([".", ".hidden", "some_folder", "some_folder/some_folder"]) │
│ +    assert paths == snapshot([".", "some_folder", "some_folder/some_folder", '.hidden']) │
╰───────────────────────────────────────────────────────────────────────────────────────────╯
Do you want to fix these snapshots? [y/n] (n): 
```