### PR TITLE
Add riscv64 build, make Linux wheel build matrix more explicit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,9 @@ jobs:
           - runner: ubuntu-22.04
             arch: ppc64le
             target: powerpc64le-unknown-linux-gnu
+          - runner: ubuntu-22.04
+            arch: riscv64
+            target: riscv64gc-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,17 +21,23 @@ jobs:
       matrix:
         platform:
           - runner: ubuntu-22.04
-            target: x86_64
+            arch: x86_64
+            target: x86_64-unknown-linux-gnu
           - runner: ubuntu-22.04
-            target: x86
+            arch: x86
+            target: i686-unknown-linux-gnu
           - runner: ubuntu-22.04
-            target: aarch64
+            arch: aarch64
+            target: aarch64-unknown-linux-gnu
           - runner: ubuntu-22.04
-            target: armv7
+            arch: armv7
+            target: armv7-unknown-linux-gnueabihf
           - runner: ubuntu-22.04
-            target: s390x
+            arch: s390x
+            target: s390x-unknown-linux-gnu
           - runner: ubuntu-22.04
-            target: ppc64le
+            arch: ppc64le
+            target: powerpc64le-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6
@@ -48,7 +54,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
   musllinux:

--- a/.github/workflows/post-summary-comment.yml
+++ b/.github/workflows/post-summary-comment.yml
@@ -28,9 +28,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Try the workflow run's pull_requests array first (works for same-repo PRs)
           PR_NUMBER=$(gh api \
             repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }} \
-            --jq '.pull_requests[0].number')
+            --jq '.pull_requests[0].number // empty')
+
+          # For fork PRs, pull_requests is empty — search by head SHA instead
+          if [ -z "$PR_NUMBER" ]; then
+            HEAD_SHA=${{ github.event.workflow_run.head_sha }}
+            PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --state open \
+              --json number,headRefOid \
+              --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | .number")
+          fi
+
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Post PR comment


### PR DESCRIPTION
maturin supports riscv64 cross build, but the arch string and the target toolchain for rustc don't exactly match up (this is also the case for other architectures like ppc64le and x86). To make the riscv64 addition consistent with the others, change the platform list so that arch and target are distinct fields.

Note that this is being done on behalf of the [RISE Project](https://riseproject.dev/) to improve Python ecosystem support on riscv64 platforms.